### PR TITLE
Prevent hanging when using older versions of tmux

### DIFF
--- a/autoload/tmuxline.vim
+++ b/autoload/tmuxline.vim
@@ -127,7 +127,7 @@ fun! tmuxline#apply(line_settings) abort
   let temp_file = tempname()
   try
     call writefile(a:line_settings, temp_file)
-    call system("tmux source " . tmuxline#util#wrap_in_quotes(temp_file))
+    call system("tmux source " . tmuxline#util#wrap_in_quotes(temp_file) . " | cat")
   finally
     call delete(temp_file)
   endtry


### PR DESCRIPTION
Using tmuxline with tmux 1.6 would cause vim to hang on startup. The code in question was https://github.com/edkolev/tmuxline.vim/blob/master/autoload/tmuxline.vim#L130:
```
call system("tmux source " . tmuxline#util#wrap_in_quotes(temp_file))
```
which in effect ran the following bash command:
```bash
(tmux source /tmp/xxxxx/0) >/tmp/xxxxx/1 2>&1
```
which causes bash to hang. But if `tmux source ...` is executed without the piping, it would return normally, and give a warning that one of the options was not available.

I don't know the exact reason behind this, but I tried changing the line of code into:
```
call system("tmux source " . tmuxline#util#wrap_in_quotes(temp_file) . " | cat")
```
and vim could start normally.

This sure is a rare problem (few would still use tmux 1.6 as of now), but I don't think adding a patch would hurt compatibility with other versions.